### PR TITLE
Reorg API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 cmake-build-debug/
 .idea
 *~
+gdb.txt
+core

--- a/examples/hello_nvme_bdev_rust_wrapper/README.md
+++ b/examples/hello_nvme_bdev_rust_wrapper/README.md
@@ -1,4 +1,4 @@
 This directory contains Rust version of hello_nvme_bdev.c program. Unlike the program
 inside hello_nvme_bdev_rust, the program here uses the Rust API we developed from
-rust-spdk. This program is used as a way to test the functionality of Rust API we 
+spdk-rs. This program is used as a way to test the functionality of Rust API we 
 designed.

--- a/examples/hello_nvme_bdev_rust_wrapper/src/main.rs
+++ b/examples/hello_nvme_bdev_rust_wrapper/src/main.rs
@@ -13,8 +13,7 @@
 
 extern crate spdk_rs;
 
-use spdk_rs::{AppOpts, AppContext, app_stop, Bdev};
-
+use spdk_rs::{spdk_app_stop, AppContext, SpdkAppOpts, Bdev};
 
 fn hello_start(context: &mut AppContext) {
     println!("Successfully started the application");
@@ -27,14 +26,14 @@ fn hello_start(context: &mut AppContext) {
     match context.set_bdev(){
         Err(_e) => {
             println!("{}", _e.to_owned());
-            app_stop(false);
+            spdk_app_stop(false);
         },
         Ok(_) => ()
     };
     match context.spdk_bdev_open(true) {
         Err(_e) => {
             println!("{}", _e.to_owned());
-            app_stop(false);
+            spdk_app_stop(false);
         }
         Ok(_) => ()
     }
@@ -42,18 +41,27 @@ fn hello_start(context: &mut AppContext) {
         Err(_e) => {
             println!("{}", _e.to_owned());
             context.spdk_bdev_close();
-            app_stop(false);
+            spdk_app_stop(false);
+        }
+        Ok(_) => ()
+    }
+    match context.allocate_buff() {
+        Err(_e) => {
+            println!("{}", _e.to_owned());
+            context.spdk_bdev_put_io_channel();
+            context.spdk_bdev_close();
+            spdk_app_stop(false);
         }
         Ok(_) => ()
     }
     context.spdk_bdev_close();
-    app_stop(true);
+    spdk_app_stop(true);
 }
 
 fn main()
 {
     println!("Enter main");
-    let mut opts = AppOpts::new();
+    let mut opts = SpdkAppOpts::new();
     opts.name("hello_bdev");
     opts.config_file("/home/zeyuanhu/rustfs/examples/hello_nvme_bdev/bdev.conf");
 

--- a/spdk-rs/src/bdev.rs
+++ b/spdk-rs/src/bdev.rs
@@ -54,6 +54,21 @@ impl<'app_context> Bdev<'app_context> {
         }
     }
 
+    pub fn spdk_bdev_open(bdev : &Bdev, write: bool, bdev_desc: &mut BdevDesc) -> Result<i32, String> {
+        unsafe {
+            let rc = raw::spdk_bdev_open(bdev.to_raw(), write, None, ptr::null_mut(), bdev_desc.mut_to_raw());
+            match rc != 0 {
+                true => {
+                    let s = format!("Could not open bdev: {}", bdev.name());
+                    Err(s)
+                }
+                false => {
+                    Ok(0)
+                }
+            }
+        }
+    }
+
     pub fn spdk_bdev_get_by_name(bdev_name: &str) -> Result<Bdev, String> {
         unsafe {
             let c_str = CString::new(bdev_name).unwrap();
@@ -100,5 +115,9 @@ impl<'app_context> BdevDesc<'app_context> {
 
     pub fn to_raw(&self) -> *mut raw::spdk_bdev_desc {
         self.raw
+    }
+
+    pub fn mut_to_raw(&mut self) -> *mut *mut raw::spdk_bdev_desc {
+        &mut self.raw
     }
 }

--- a/spdk-rs/src/bdev.rs
+++ b/spdk-rs/src/bdev.rs
@@ -6,6 +6,11 @@
   > Description:
     
     FFI for "bdev.h"
+
+    Note that not all functions belong to "bdev.h" are implemented here.
+    For example, spdk_bdev_open() is implemented in the context instead
+    because spdk_bdev_open works with struct spdk_bdev* and
+    struct spdk_bdev_desc**, which usually used with the context struct.
  ************************************************************************/
 use {raw, AppContext};
 use std::ffi::{CString, CStr};

--- a/spdk-rs/src/context.rs
+++ b/spdk-rs/src/context.rs
@@ -1,0 +1,155 @@
+/*************************************************************************
+  > File Name:       context.rs
+  > Author:          Zeyuan Hu
+  > Mail:            iamzeyuanhu@utexas.edu
+  > Created Time:    10/10/18
+  > Description:
+    
+    An abstraction of the context that is needed for the SPDK framework.
+    This file is not part of the original spdk C API. I implement this
+    because I forsee any SPDK-based application may need to define the context struct.
+
+ ************************************************************************/
+
+use raw;
+use Bdev;
+use BdevDesc;
+
+use std::ffi::{CString, CStr};
+use std::os::raw::{c_void, c_char, c_int};
+use std::ptr;
+
+
+pub struct AppContext {
+    bdev: *mut raw::spdk_bdev,
+    bdev_desc: *mut raw::spdk_bdev_desc,
+    bdev_io_channel: *mut raw::spdk_io_channel,
+    buff: *mut c_char,
+    bdev_name: *const c_char,
+}
+
+impl AppContext {
+    pub fn new() -> AppContext {
+        AppContext {
+            bdev: ptr::null_mut(),
+            bdev_desc: ptr::null_mut(),
+            bdev_io_channel: ptr::null_mut(),
+            buff: ptr::null_mut(),
+            bdev_name: ptr::null_mut(),
+        }
+    }
+
+    pub fn set_bdev_name(&mut self, name: &str) {
+        self.bdev_name = CString::new(name)
+            .expect("Couldn't create a string")
+            .into_raw()
+    }
+
+    pub fn bdev_name(&self) -> &str {
+        unsafe {
+            let c_buf: *const c_char = self.bdev_name;
+            let c_str: &CStr = CStr::from_ptr(c_buf);
+            let str_slice: &str = c_str.to_str().unwrap();
+            str_slice
+        }
+    }
+
+    pub fn bdev(&self) -> Option<Bdev> {
+        Some(Bdev::from_raw(self.bdev))
+    }
+
+    /// set bdev field based on the bdev_name
+    ///
+    /// **NOTE:** The implementation can be improved becaseu we essentially
+    /// duplicate code of bdev_name. The reason we doing so as a way to workaround
+    /// the borrow checker. See more info about the issue I'm facing during the implementation
+    /// [here](https://stackoverflow.com/questions/52709147/how-to-workaround-the-coexistence-of-a-mutable-and-immutable-borrow)
+    pub fn set_bdev(&mut self) -> Result<i32, String> {
+        let str_slice;
+        unsafe {
+            let c_buf: *const c_char = self.bdev_name;
+            let c_str: &CStr = CStr::from_ptr(c_buf);
+            str_slice = c_str.to_str().unwrap();
+        }
+        let bdev = Bdev::spdk_bdev_get_by_name(str_slice);
+        match bdev {
+            Err(E) => {
+                let s = E.to_owned();
+                Err(s)
+            }
+            Ok(T) => {
+                self.bdev = T.to_raw();
+                Ok(0)
+            }
+        }
+    }
+
+    pub fn bdev_desc(&self) -> Option<BdevDesc> {
+        Some(BdevDesc::from_raw(self.bdev_desc))
+    }
+
+    /// # Parameters
+    ///
+    /// - context: the context when start the SPDK framework
+    /// - write: true is read/write access requested, false if read-only
+    ///
+    pub fn spdk_bdev_open(&mut self, write: bool) -> Result<i32, String> {
+        unsafe {
+            let rc = raw::spdk_bdev_open(self.bdev, write, None, ptr::null_mut(), &mut self.bdev_desc);
+            match rc != 0 {
+                true => {
+                    let s = format!("Could not open bdev: {}", self.bdev_name());
+                    Err(s)
+                }
+                false => {
+                    Ok(0)
+                }
+            }
+        }
+    }
+
+    pub fn spdk_bdev_close(&mut self) {
+        unsafe {
+            raw::spdk_bdev_close(self.bdev_desc);
+        }
+    }
+
+    pub fn spdk_bdev_get_io_channel(&mut self) -> Result<i32, String> {
+        unsafe {
+            let ptr = raw::spdk_bdev_get_io_channel(self.bdev_desc);
+            match ptr.is_null() {
+                true => {
+                    let s = format!("Could not create bdev I/O channel!!");
+                    Err(s)
+                }
+                false => {
+                    self.bdev_io_channel = ptr;
+                    Ok(0)
+                }
+            }
+        }
+    }
+
+    pub fn spdk_bdev_put_io_channel(&self) {
+        unsafe {
+            raw::spdk_put_io_channel(self.bdev_io_channel)
+        }
+    }
+
+    pub fn allocate_buff(&mut self) -> Result<i32, String> {
+        unsafe {
+            self.buff = raw::spdk_dma_zmalloc(raw::spdk_bdev_get_block_size(self.bdev) as usize,
+                                         raw::spdk_bdev_get_buf_align(self.bdev),
+                                         ptr::null_mut()) as *mut c_char;
+            match self.buff.is_null() {
+                true => {
+                    let s = format!("Failed to allocate buffer");
+                    Err(s)
+                }
+                false => {
+                    Ok(0)
+                }
+            }
+        }
+    }
+}

--- a/spdk-rs/src/env.rs
+++ b/spdk-rs/src/env.rs
@@ -1,0 +1,9 @@
+/*************************************************************************
+  > File Name:       env.rs
+  > Author:          Zeyuan Hu
+  > Mail:            iamzeyuanhu@utexas.edu
+  > Created Time:    10/10/18
+  > Description:
+    
+    FFI for "env.h"
+ ************************************************************************/

--- a/spdk-rs/src/event.rs
+++ b/spdk-rs/src/event.rs
@@ -20,130 +20,16 @@ enum AppError {
     StartupError(i32),
 }
 
-pub struct AppContext {
-    bdev: *mut raw::spdk_bdev,
-    bdev_desc: *mut raw::spdk_bdev_desc,
-    bdev_io_channel: *mut raw::spdk_io_channel,
-    buff: *mut c_char,
-    bdev_name: *const c_char,
-}
-
-impl AppContext {
-    pub fn new() -> AppContext {
-        AppContext {
-            bdev: ptr::null_mut(),
-            bdev_desc: ptr::null_mut(),
-            bdev_io_channel: ptr::null_mut(),
-            buff: ptr::null_mut(),
-            bdev_name: ptr::null_mut(),
-        }
-    }
-
-    pub fn set_bdev_name(&mut self, name: &str) {
-        self.bdev_name = CString::new(name)
-            .expect("Couldn't create a string")
-            .into_raw()
-    }
-
-    pub fn bdev_name(&self) -> &str {
-        unsafe {
-            let c_buf: *const c_char = self.bdev_name;
-            let c_str: &CStr = CStr::from_ptr(c_buf);
-            let str_slice: &str = c_str.to_str().unwrap();
-            str_slice
-        }
-    }
-
-    pub fn bdev(&self) -> Option<Bdev> {
-        Some(Bdev::from_raw(self.bdev))
-    }
-
-    /// set bdev field based on the bdev_name
-    ///
-    /// **NOTE:** The implementation can be improved becaseu we essentially
-    /// duplicate code of bdev_name. The reason we doing so as a way to workaround
-    /// the borrow checker. See more info about the issue I'm facing during the implementation
-    /// [here](https://stackoverflow.com/questions/52709147/how-to-workaround-the-coexistence-of-a-mutable-and-immutable-borrow)
-    pub fn set_bdev(&mut self) -> Result<i32, String> {
-        let str_slice;
-        unsafe {
-            let c_buf: *const c_char = self.bdev_name;
-            let c_str: &CStr = CStr::from_ptr(c_buf);
-            str_slice = c_str.to_str().unwrap();
-        }
-        let bdev = Bdev::spdk_bdev_get_by_name(str_slice);
-        match bdev {
-            Err(E) => {
-                let s = E.to_owned();
-                Err(s)
-            }
-            Ok(T) => {
-                self.bdev = T.to_raw();
-                Ok(0)
-            }
-        }
-    }
-
-    pub fn bdev_desc(&self) -> Option<BdevDesc> {
-        Some(BdevDesc::from_raw(self.bdev_desc))
-    }
-
-    /// # Parameters
-    ///
-    /// - context: the context when start the SPDK framework
-    /// - write: true is read/write access requested, false if read-only
-    ///
-    pub fn spdk_bdev_open(&mut self, write: bool) -> Result<i32, String> {
-        unsafe {
-            let rc = raw::spdk_bdev_open(self.bdev, write, None, ptr::null_mut(), &mut self.bdev_desc);
-            match rc != 0 {
-                true => {
-                    let s = format!("Could not open bdev: {}", self.bdev_name());
-                    Err(s)
-                }
-                false => {
-                    Ok(0)
-                }
-            }
-        }
-    }
-
-    pub fn spdk_bdev_close(&mut self) {
-        unsafe {
-            raw::spdk_bdev_close(self.bdev_desc);
-        }
-    }
-
-    pub fn spdk_bdev_get_io_channel(&mut self) -> Result<i32, String> {
-        unsafe {
-            let ptr = raw::spdk_bdev_get_io_channel(self.bdev_desc);
-            match ptr.is_null() {
-                true => {
-                    let s = format!("Could not create bdev I/O channel!!");
-                    Err(s)
-                }
-                false => {
-                    self.bdev_io_channel = ptr;
-                    Ok(0)
-                }
-            }
-        }
-    }
-}
-
-
-// tuple struct: https://doc.rust-lang.org/1.9.0/book/structs.html
-// https://stackoverflow.com/questions/30339831/what-are-some-use-cases-for-tuple-structs
 #[derive(Default)]
-pub struct AppOpts(raw::spdk_app_opts);
+pub struct SpdkAppOpts(raw::spdk_app_opts);
 
-impl AppOpts {
+impl SpdkAppOpts {
     pub fn new() -> Self {
         let mut opts: raw::spdk_app_opts = Default::default();
         unsafe {
             raw::spdk_app_opts_init(&mut opts as *mut raw::spdk_app_opts);
         }
-        AppOpts(opts)
+        SpdkAppOpts(opts)
     }
 
     pub fn name(&mut self, name: &str) {
@@ -198,21 +84,21 @@ impl AppOpts {
     }
 }
 
-pub fn app_stop(success: bool) {
+pub fn spdk_app_stop(success: bool) {
     unsafe {
         raw::spdk_app_stop(if success { 0 } else { -1 });
     };
 }
 
-impl Drop for AppOpts {
-    fn drop(&mut self) {
-        drop_if_not_null(self.0.name as *mut c_char);
-        drop_if_not_null(self.0.config_file as *mut c_char);
-    }
-}
-
-fn drop_if_not_null(string: *mut c_char) {
-    if !string.is_null() {
-        unsafe { CString::from_raw(string as *mut c_char) };
-    }
-}
+//impl Drop for SpdAppOpts {
+//    fn drop(&mut self) {
+//        drop_if_not_null(self.0.name as *mut c_char);
+//        drop_if_not_null(self.0.config_file as *mut c_char);
+//    }
+//}
+//
+//fn drop_if_not_null(string: *mut c_char) {
+//    if !string.is_null() {
+//        unsafe { CString::from_raw(string as *mut c_char) };
+//    }
+//}

--- a/spdk-rs/src/lib.rs
+++ b/spdk-rs/src/lib.rs
@@ -7,6 +7,8 @@ extern crate libc;
 
 mod event;
 mod bdev;
+mod context;
 
-pub use event::{AppOpts, AppContext, app_stop};
+pub use event::{SpdkAppOpts, spdk_app_stop};
 pub use bdev::{Bdev, BdevDesc};
+pub use context::{AppContext};


### PR DESCRIPTION
Create this branch to explore the idea of organizing say `spdk_bdev_open` under the `bdev.rs` instead of attaching it under the `AppContext` struct. We wrap the raw binding of `spdk_bdev_open` inside `bdev.rs`
and `AppContext` has the same name function, which simply calls the `spdk_bdev_open` wrapper under `bdev.rs`. There is tradeoff between separation of concern and the performance: when calling `spdk_bdev_open` in `bdev.rs`, we need to pack the field of the `AppContext` struct and send it to the underlying function to be modified and once the underlying function returns, we need to unpack the object to update our field. I only implement the `spdk_bdev_open` as a POC.